### PR TITLE
Add option to only show running net interfaces in status bar

### DIFF
--- a/doc/icewm.adoc
+++ b/doc/icewm.adoc
@@ -1037,6 +1037,10 @@ List of battery names ignore.
 +
 Show CPU frequency in CPU status tool tip.
 
+* `NetStatusShowOnlyRunning = 0`
++
+Show network status for running devices only.
+
 * `TaskBarShowMEMStatus = 1`
 +
 Show memory usage status on task bar (Linux only).

--- a/doc/icewm.adoc
+++ b/doc/icewm.adoc
@@ -1039,7 +1039,9 @@ Show CPU frequency in CPU status tool tip.
 
 * `NetStatusShowOnlyRunning = 0`
 +
-Show network status for running devices only.
+Show network status only for connected devices, such as an active ethernet link
+or associated wireless interface. If false, any network interface that has been
+brought up will be displayed.
 
 * `TaskBarShowMEMStatus = 1`
 +

--- a/man/icewm-preferences.pod
+++ b/man/icewm-preferences.pod
@@ -510,6 +510,10 @@ Show ACPI temperature in CPU status bar.
 
 Show CPU frequency in CPU status tool tip.
 
+=item B<NetStatusShowOnlyRunning>=0
+
+Show network status for running devices only.
+
 =item B<TaskBarShowMEMStatus>=1
 
 Show memory usage status on task bar (Linux only).

--- a/man/icewm-preferences.pod
+++ b/man/icewm-preferences.pod
@@ -512,7 +512,9 @@ Show CPU frequency in CPU status tool tip.
 
 =item B<NetStatusShowOnlyRunning>=0
 
-Show network status for running devices only.
+Show network status only for connected devices, such as an active ethernet link
+or associated wireless interface. If false, any network interface that has been
+brought up will be displayed.
 
 =item B<TaskBarShowMEMStatus>=1
 

--- a/src/apppstatus.cc
+++ b/src/apppstatus.cc
@@ -35,14 +35,14 @@ extern ref<YPixmap> taskbackPixmap;
 
 class NetDevice : public INetDevice {
 public:
-    NetDevice(mstring netdev) : fDevName(netdev) {
-        should_display_flag = netstatusShowOnlyRunning ? IFF_RUNNING : IFF_UP;
-    }
+    NetDevice(mstring netdev) : fDevName(netdev) {}
     const char* getPhoneNumber() override { return ""; }
     mstring name() const { return fDevName; }
 protected:
     mstring fDevName;
-    int should_display_flag;
+    int shouldDisplayFlag() const {
+        return netstatusShowOnlyRunning ? IFF_RUNNING : IFF_UP;
+    }
 };
 
 class NetLinuxDevice : public NetDevice {
@@ -387,7 +387,7 @@ bool NetOpenDevice::isUp() {
         struct ifreq ifr;
         strlcpy(ifr.ifr_name, fDevName, IFNAMSIZ);
         if (ioctl(s, SIOCGIFFLAGS, (caddr_t)&ifr) != -1) {
-            up = (ifr.ifr_flags & should_display_flag);
+            up = (ifr.ifr_flags & shouldDisplayFlag());
         }
         close(s);
     }
@@ -420,7 +420,7 @@ bool NetFreeDevice::isUp() {
                 continue;
             }
             if (fDevName == ifmd.ifmd_name) {
-                return (ifmd.ifmd_flags & should_display_flag);
+                return (ifmd.ifmd_flags & shouldDisplayFlag());
             }
         }
     }
@@ -436,7 +436,7 @@ bool NetLinuxDevice::isUp() {
 
     struct ifreq ifr;
     strlcpy(ifr.ifr_name, fDevName, IFNAMSIZ);
-    bool up = (ioctl(s, SIOCGIFFLAGS, &ifr) >= 0 && (ifr.ifr_flags & should_display_flag));
+    bool up = (ioctl(s, SIOCGIFFLAGS, &ifr) >= 0 && (ifr.ifr_flags & shouldDisplayFlag()));
     close(s);
     return up;
 }

--- a/src/apppstatus.cc
+++ b/src/apppstatus.cc
@@ -35,11 +35,14 @@ extern ref<YPixmap> taskbackPixmap;
 
 class NetDevice : public INetDevice {
 public:
-    NetDevice(mstring netdev) : fDevName(netdev) {}
+    NetDevice(mstring netdev) : fDevName(netdev) {
+        should_display_flag = netstatusShowOnlyRunning ? IFF_RUNNING : IFF_UP;
+    }
     const char* getPhoneNumber() override { return ""; }
     mstring name() const { return fDevName; }
 protected:
     mstring fDevName;
+    int should_display_flag;
 };
 
 class NetLinuxDevice : public NetDevice {
@@ -384,7 +387,7 @@ bool NetOpenDevice::isUp() {
         struct ifreq ifr;
         strlcpy(ifr.ifr_name, fDevName, IFNAMSIZ);
         if (ioctl(s, SIOCGIFFLAGS, (caddr_t)&ifr) != -1) {
-            up = (ifr.ifr_flags & IFF_UP);
+            up = (ifr.ifr_flags & should_display_flag);
         }
         close(s);
     }
@@ -417,7 +420,7 @@ bool NetFreeDevice::isUp() {
                 continue;
             }
             if (fDevName == ifmd.ifmd_name) {
-                return (ifmd.ifmd_flags & IFF_UP);
+                return (ifmd.ifmd_flags & should_display_flag);
             }
         }
     }
@@ -433,7 +436,7 @@ bool NetLinuxDevice::isUp() {
 
     struct ifreq ifr;
     strlcpy(ifr.ifr_name, fDevName, IFNAMSIZ);
-    bool up = (ioctl(s, SIOCGIFFLAGS, &ifr) >= 0 && (ifr.ifr_flags & IFF_UP));
+    bool up = (ioctl(s, SIOCGIFFLAGS, &ifr) >= 0 && (ifr.ifr_flags & should_display_flag));
     close(s);
     return up;
 }

--- a/src/default.h
+++ b/src/default.h
@@ -76,6 +76,7 @@ XIV(bool, cpustatusShowSwapUsage,               true)
 XIV(bool, cpustatusShowAcpiTemp,                true)
 XIV(bool, cpustatusShowAcpiTempInGraph,         false)
 XIV(bool, cpustatusShowCpuFreq,                 true)
+XIV(bool, netstatusShowOnlyRunning,             false)
 XIV(bool, taskBarShowMEMStatus,                 true)
 XIV(bool, taskBarShowNetStatus,                 true)
 XIV(bool, taskBarLaunchOnSingleClick,           true)
@@ -329,6 +330,7 @@ cfoption icewm_preferences[] = {
     OBV("CPUStatusShowAcpiTemp",                &cpustatusShowAcpiTemp,         "Show ACPI temperature in CPU status tool tip"),
     OBV("CPUStatusShowAcpiTempInGraph",         &cpustatusShowAcpiTempInGraph,  "Show ACPI temperature in CPU status bar"),
     OBV("CPUStatusShowCpuFreq",                 &cpustatusShowCpuFreq,          "Show CPU frequency in CPU status tool tip"),
+    OBV("NetStatusShowOnlyRunning",             &netstatusShowOnlyRunning,      "Show network status for running devices only"),
     OBV("TaskBarShowMEMStatus",                 &taskBarShowMEMStatus,          "Show memory usage status on task bar (Linux only)"),
     OBV("TaskBarShowNetStatus",                 &taskBarShowNetStatus,          "Show network status on task bar"),
     OBV("TaskBarShowCollapseButton",            &taskBarShowCollapseButton,     "Show a button to collapse the taskbar"),


### PR DESCRIPTION
NetStatusShowOnlyRunning, if enabled, will cause the status bar to check
for the IFF_RUNNING bit instead of the IFF_UP bit to determine if an
interface should be displayed in the status bar.

See https://man7.org/linux/man-pages/man7/netdevice.7.html and https://stackoverflow.com/a/11679939/5760230. 

This is useful for example when using a bond interface. The interfaces that are not connected (e.g. an unplugged ethernet cable) will not have bars in the status bar.