### PR TITLE
aapm: replace to faster conversion str to num in SysFS::read()

### DIFF
--- a/src/aapm.cc
+++ b/src/aapm.cc
@@ -91,10 +91,13 @@ bool SysFS::read(const char* name, long* num) {
     const size_t bufsize = 256;
     char buf[bufsize];
     if (read(name, buf)) {
-        if (sscanf(buf, "%ld", num) <= 0)
-            *num = -1;
-        else
+        char* endptr;
+        *num = strtol(buf, &endptr, 10);
+        if (endptr != buf) {
             got = true;
+        } else {
+            *num = -1;
+        }
     }
     return got;
 }


### PR DESCRIPTION
@gijsbers,

How do you like this change? The `read()` method uses too slow conversion string to number, according to benchmarks, using `sscanf()` for this purpose is about 8-10 times less fast `strtol()`.

References:
- https://stackoverflow.com/questions/58778829/fast-alternative-to-sscanf
- https://stackoverflow.com/questions/22865622/atoi-vs-atol-vs-strtol-vs-strtoul-vs-sscanf